### PR TITLE
Fixed an issue where get-pip.py URL was no working with python3.8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN set -x && apt -y install libgl1-mesa-dev libglib2.0-0 zip git
 RUN set -x \
     && apt -y install python3.8 python3.8-dev \
     && ln -s /usr/bin/python3.8 /usr/bin/python \
-    && apt -y install wget python3-distutils && wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && python -m pip install --upgrade pip==24.0
+    && apt -y install wget python3-distutils && wget https://bootstrap.pypa.io/pip/3.8/get-pip.py && python get-pip.py && python -m pip install --upgrade pip==24.0
 
 COPY . ${PROJECT_DIR}
 


### PR DESCRIPTION
The minimum execution environment for https://bootstrap.pypa.io/get-pip.py has been updated to Python 3.9, so the URL has been changed to one for Python 3.8.